### PR TITLE
Resubscribes emails in "pending" state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@
 
 Putting the dump file in the config bucket is a simple way to get it loaded into
 a container.
+
+### Testing
+
+#### Upaknee subscriptions
+
+```
+curl -k -X POST -d "subscriber[email]=XXXXXXX" -d "subscriber[zipcode]=02201" 'https://localhost:5000/subscriptions?list=2' 
+```

--- a/app/lib/subscribe_bot.rb
+++ b/app/lib/subscribe_bot.rb
@@ -4,28 +4,35 @@ class SubscribeBot
   BOT_AUTH = "#{ENV['API_KEY']}:#{ENV['API_PASS']}"
 
   def initialize
-    puts BOT_AUTH
+    puts ENV['API_KEY']
     puts BOT_BASE_URI
     puts BOT_HEADERS
   end
 
-  def check_subscriber(id)
-    response = Typhoeus::Request.get("#{BOT_BASE_URI}/subscribers/#{id}",
+  def check_subscriber(profile_id)
+    return Typhoeus::Request.get("#{BOT_BASE_URI}/subscribers/#{profile_id}",
       userpwd: BOT_AUTH,
       headers: BOT_HEADERS
     )
   end
 
-  def create_subscriber(contact)
-    response = Typhoeus::Request.post("#{BOT_BASE_URI}/subscribers",
+  def resubscribe(profile_id)
+    return Typhoeus::Request.get("#{BOT_BASE_URI}/subscribers/#{profile_id}/resubscribe",
       userpwd: BOT_AUTH,
-      headers: BOT_HEADERS,
-      body: contact.to_xml( :only => [:email, :profile_id, :zipcode] )
+      headers: BOT_HEADERS
     )
   end
 
-  def add_subscription(contact, list)
-    response = Typhoeus::Request.post("#{BOT_BASE_URI}/subscribers/#{contact}/subscriptions",
+  def create_subscriber(subscriber)
+    return Typhoeus::Request.post("#{BOT_BASE_URI}/subscribers",
+      userpwd: BOT_AUTH,
+      headers: BOT_HEADERS,
+      body: subscriber.to_xml( :only => [:email, :profile_id, :zipcode] )
+    )
+  end
+
+  def add_subscription(profile_id, list)
+    return Typhoeus::Request.post("#{BOT_BASE_URI}/subscribers/#{profile_id}/subscriptions",
       userpwd: BOT_AUTH,
       headers: BOT_HEADERS,
       body: {subscription: {newsletter_id: list}}.to_xml(root: "subscriptions")
@@ -33,7 +40,7 @@ class SubscribeBot
   end
 
   def validate_email(email)
-    response = Typhoeus::Request.get("#{BOT_BASE_URI}/subscribers/#{email}/validate",
+    return Typhoeus::Request.get("#{BOT_BASE_URI}/subscribers/#{email}/validate",
       userpwd: BOT_AUTH,
       headers: BOT_HEADERS
     )


### PR DESCRIPTION
Makes the verification email go out again if a user re-enters their
email address. Before this, verification was only sent once, so if folks
lost it they just wouldn't get any emails at all.